### PR TITLE
Optimize for reduced storage usage

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,7 +1,0 @@
-FROM tianon/true
-
-LABEL Description="Pre-initialized mariadb datadir"
-
-COPY mysql /var/lib/mysql
-
-VOLUME [ "/var/lib/mysql" ]

--- a/src/build-datadir-image.sh
+++ b/src/build-datadir-image.sh
@@ -27,19 +27,19 @@ show_system_state() {
 cleanup() {
   echo "Cleanup called."
 
-  if [[ ! -z "${DB_CONTAINER_NAME-}" ]]
+  if [[ ! -z "${DB_CONTAINER_NAME:-}" ]]
   then
     echo "Removing container ${DB_CONTAINER_NAME}."
     docker rm -f "${DB_CONTAINER_NAME}"
   fi
 
-  if [[ ! -z "${DUMP_VOLUME-}" ]]
+  if [[ ! -z "${DUMP_VOLUME:-}" ]]
     then
       echo "Removing dump volume ${DUMP_VOLUME}."
       docker volume rm -f "${DUMP_VOLUME}"
   fi
 
-  if [[ ! -z "${DATADIR_VOLUME-}" ]]
+  if [[ ! -z "${DATADIR_VOLUME:-}" ]]
     then
       echo "Removing datadir volume ${DATADIR_VOLUME}."
       docker volume rm -f "${DATADIR_VOLUME}"

--- a/src/build-datadir-image.sh
+++ b/src/build-datadir-image.sh
@@ -14,10 +14,13 @@ error() {
 
 show_system_state() {
   echo "Dumping usage status:"
-  echo "w"
+  echo "*** LOCAL w"
   w
-  echo "df -h"
+  echo "*** LOCAL df -h"
   df -h
+
+  echo "*** CONTAINER df -h"
+  docker run alpine df -h
 }
 
 # Remove volumes and containers.
@@ -41,6 +44,7 @@ cleanup() {
       echo "Removing datadir volume ${DATADIR_VOLUME}."
       docker volume rm -f "${DATADIR_VOLUME}"
   fi
+  show_system_state
 }
 
 # Remove all temporary data we can get our hands on.
@@ -192,8 +196,7 @@ if [[ -z "${NO_PUSH-}" ]]; then
   echo "Pushing ${DATADIR_IMAGE_DESTINATION}"
   docker push "${DATADIR_IMAGE_DESTINATION}"
   docker rmi "${DATADIR_IMAGE_DESTINATION}"
+  show_system_state
 else
   echo "Datadir image is available as ${DATADIR_IMAGE_DESTINATION}"
 fi
-
-show_system_state

--- a/src/build-datadir-image.sh
+++ b/src/build-datadir-image.sh
@@ -160,9 +160,11 @@ docker cp "${INIT_ONLY_ENTRYPOINT}" "${DB_CONTAINER_NAME}:/docker-entrypoint.sh"
 echo "Initializing container with dbdump"
 docker start -a "${DB_CONTAINER_NAME}"
 
-# Setup the final destination for the datadir
-TMP_DATADIR=$(mktemp -d --suffix=datadir)
-docker cp -a "${DB_CONTAINER_NAME}:/var/lib/mysql" "${TMP_DATADIR}/mysql"
+# Setup the final destination for the datadir, we use /workspace as it's
+# a mountpoint with plenty of spaces in Google Cloud Build.
+TMP_DATADIR=/workspace/datadir
+mkdir -p "${TMP_DATADIR}/var/lib/"
+docker cp -a "${DB_CONTAINER_NAME}:/var/lib/mysql" "${TMP_DATADIR}/var/lib/mysql"
 
 # Do some intermediary cleanup already to avoid blowing up the 100GB disk limit.
 show_system_state


### PR DESCRIPTION
This PR attempts to reduce our storage-usage during build by using a `docker 
create container` instead of `docker build` which has to juggle our datadir
a bit to much while handling the build context.

Besides that I introduce a bit of extra debugging and a couple of minor
bugfixes that would hit us if a variable was not set.